### PR TITLE
Add helper make() method for pure context arguments

### DIFF
--- a/Sources/LeafProvider/LeafRenderer.swift
+++ b/Sources/LeafProvider/LeafRenderer.swift
@@ -22,10 +22,13 @@ public final class LeafRenderer: ViewRenderer {
         shouldCache = false
         self.cacheSize = cacheSize ?? 8
     }
-
-    public func make(_ path: String, _ context: Node) throws -> View {
+    
+    public func make(_ path: String, _ node: Node) throws -> View {
+        return try self.make(path, Context(node))
+    }
+    
+    public func make(_ path: String, _ context: LeafContext) throws -> View {
         let leaf = try stem.spawnLeaf(at: path)
-        let context = Context(context)
         let bytes = try stem.render(leaf, with: context)
         return View(data: bytes)
     }


### PR DESCRIPTION
@LoganWright this is handy shortcut for make() method. 

Sometimes you need pure "Context" argument, not "Node" for view.make - for example in case of inheritance, where Context provides helpful 'push' method:

<img width="610" alt="zrzut ekranu 2017-07-01 o 00 35 01" src="https://user-images.githubusercontent.com/552398/27756206-e54899ec-5df5-11e7-9780-f13c63cb75bf.png">
